### PR TITLE
Add and update fields

### DIFF
--- a/django_etuovi/enums.py
+++ b/django_etuovi/enums.py
@@ -60,7 +60,7 @@ class ItemGroup(Enum):
     RENTAL = "Vuokra-asunnot"
     ESTATE = "Maa- ja metsätilat"
     LOT = "Tontit"
-    NEW_BUILDING = "Uudiskohteet"
+    NEW_HOUSING = "Uudiskohteet"
     CARAGE_OR_OTHER = "Autotallit ja muut"
 
 
@@ -133,7 +133,7 @@ class LinkType(Enum):
     AD_6 = "Mainos 6"
     PDF_PRESENTATION = "PDF -esitteen linkki"
     DETAILED_PRESENTATION = "Tarkempiesittelylinkki"
-    NEW_HOUSE = "Uudiskohdelinkki"
+    NEW_HOUSING = "Uudiskohdelinkki"
     SEARCH_WATCH_AD = "Vahtiviestimainos"
     VIDEO = "Videolinkki"
     VIRTUAL = "Virtuaalilinkki"
@@ -319,3 +319,4 @@ class RealtyOption(Enum):
     NO_SAUNA = "ei saunaa"
     OWN_SAUNA = "oma sauna"
     HOUSING_SAUNA = "taloyhtiössä sauna"
+    YARD = "piha"

--- a/django_etuovi/etuovi.py
+++ b/django_etuovi/etuovi.py
@@ -36,7 +36,7 @@ def get_session() -> FTP:
 def send_items(items: List[BaseClass]) -> None:
     element_tree = ElementTree(create_element_tree(items))
     filename = get_filename()
-    element_tree.write(filename, encoding="utf-8", xml_declaration=True)
+    element_tree.write(filename, encoding="ISO-8859-1", xml_declaration=True)
 
     session = get_session()
     session.storbinary("{}.temp".format(filename), open(filename, "rb"))

--- a/django_etuovi/items.py
+++ b/django_etuovi/items.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import date
 from decimal import Decimal
 from typing import List
 
@@ -69,6 +70,8 @@ class Coordinate(BaseClass):
 @dataclass
 class Item(BaseClass):
     buildyear: int
+    charges_parkingspace: Decimal
+    chargesfinancebasemonth: Decimal
     chargesmaintbasemonth: Decimal
     chargeswater2: Decimal
     chargeswater2_period: str
@@ -80,27 +83,39 @@ class Item(BaseClass):
     debtfreeprice: Decimal
     dgitemcode: str
     energyclass: str
+    extralink: List[ExtraLink]
+    floors: int
     holdingtype: HoldingType
     image: List[Image]
     itemgroup: ItemGroup
-    extralink: List[ExtraLink]
     livingaream2: Decimal
     loclvlid: int  # If coordinate exists, this needs to be 1.
     locsourceid: int  # If coordinate exists, this needs to be 4.
+    lotarea: Decimal
+    lotareaunitcode: str
+    lotholding: str
     postcode: str
+    presentation: str
     price: Decimal
+    price_m2: Decimal
     quarteroftown: str
     realtygroup: RealtyGroup
     realtyidentifier: str
     realty_itemgroup: ItemGroup
     realtytype: RealtyType
     realtyoption: List[str]
+    rc_lot_renter: str
+    rc_zoninginfo: str
+    roof: str
     roomcount: int
+    showingdate: date
+    showingdate2: date
     street: str
     supplier_source_itemcode: str
     text: List[Text]
     town: str
     tradetype: TradeType
+    zoningname: str
 
     class Meta:
         element_name = "item"

--- a/django_etuovi/utils.py
+++ b/django_etuovi/utils.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from enum import Enum
 from typing import Union
 
 from lxml import etree
@@ -27,7 +28,7 @@ def get_root(name: str) -> etree.Element:
 
 
 def create_value_property(
-    key: Union[str, None], value: Union[int, str, Decimal], root: etree.Element
+    key: Union[str, None], value: Union[int, str, Decimal, Enum], root: etree.Element
 ) -> None:
     if key is None:
         property_element = etree.Element("property")
@@ -35,13 +36,15 @@ def create_value_property(
         property_element = etree.Element("property", name=key)
     value_element = etree.Element("value")
     property_element.append(value_element)
+    if isinstance(value, Enum):
+        value = value.value
     # Don't want to stringify None.
     value_element.text = str(value) if value is not None else value
     root.append(property_element)
 
 
 def handle_property(
-    key: Union[str, None], value: Union[int, str, Decimal], root: etree.Element
+    key: Union[str, None], value: Union[int, str, Decimal, Enum], root: etree.Element
 ) -> None:
     if isinstance(value, BaseClass):
         el = value.to_etree()
@@ -52,7 +55,7 @@ def handle_property(
 
 
 def get_property_root(
-    key: str, value: Union[int, str, Decimal], root: etree.Element
+    key: str, value: Union[int, str, Decimal, Enum], root: etree.Element
 ) -> etree.Element:
     if isinstance(value, BaseClass):
         property_name = get_name(value)

--- a/django_etuovi/utils.py
+++ b/django_etuovi/utils.py
@@ -86,7 +86,7 @@ def object_to_etree(obj: BaseClass) -> etree.Element:
     return root
 
 
-def object_to_xml_string(obj: BaseClass, encoding: str = "utf-8") -> bytes:
+def object_to_xml_string(obj: BaseClass, encoding: str = "ISO-8859-1") -> bytes:
     root = obj.to_etree()
 
     return etree.tostring(

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -24,7 +24,7 @@ class ImageFactory(factory.Factory):
         model = Image
 
     image_desc = fuzzy.FuzzyText()
-    image_realtyimagetype = fuzzy.FuzzyChoice([c.value for c in RealtyImageType])
+    image_realtyimagetype = fuzzy.FuzzyChoice([c for c in RealtyImageType])
     image_seq = fuzzy.FuzzyText()
     image_transfer_id = fuzzy.FuzzyText()
     image_transfer_source = fuzzy.FuzzyText()
@@ -37,16 +37,16 @@ class ExtraLinkFactory(factory.Factory):
 
     link_url = fuzzy.FuzzyText()
     link_urltitle = fuzzy.FuzzyText()
-    linktype_name = fuzzy.FuzzyChoice([c.value for c in LinkType])
+    linktype_name = fuzzy.FuzzyChoice([c for c in LinkType])
 
 
 class TextFactory(factory.Factory):
     class Meta:
         model = Text
 
-    text_key = fuzzy.FuzzyChoice([c.value for c in TextKey])
+    text_key = fuzzy.FuzzyChoice([c for c in TextKey])
     text_value = fuzzy.FuzzyText()
-    text_language = fuzzy.FuzzyChoice([c.value for c in TextLanguage])
+    text_language = fuzzy.FuzzyChoice([c for c in TextLanguage])
 
 
 class CoordinateFactory(factory.Factory):
@@ -67,9 +67,9 @@ class ItemFactory(factory.Factory):
     chargesmaintbasemonth = fuzzy.FuzzyDecimal(0, 99999999999)
     chargeswater2 = fuzzy.FuzzyDecimal(0, 99999999999)
     chargeswater2_period = fuzzy.FuzzyText()
-    condition_name = fuzzy.FuzzyChoice([c.value for c in Condition])
+    condition_name = fuzzy.FuzzyChoice([c for c in Condition])
     coordinate = factory.List([factory.SubFactory(CoordinateFactory)])
-    country = fuzzy.FuzzyChoice([c.value for c in Country])
+    country = fuzzy.FuzzyChoice([c for c in Country])
     currency_code = "EUR"
     cust_itemcode = fuzzy.FuzzyText()
     debtfreeprice = fuzzy.FuzzyDecimal(0, 99999999999)
@@ -77,9 +77,9 @@ class ItemFactory(factory.Factory):
     extralink = factory.List([factory.SubFactory(ExtraLinkFactory) for _ in range(2)])
     floors = fuzzy.FuzzyInteger(0, 9999999999)
     energyclass = fuzzy.FuzzyText(length=10)
-    holdingtype = fuzzy.FuzzyChoice([c.value for c in HoldingType])
+    holdingtype = fuzzy.FuzzyChoice([c for c in HoldingType])
     image = factory.List([factory.SubFactory(ImageFactory) for _ in range(2)])
-    itemgroup = fuzzy.FuzzyChoice([c.value for c in ItemGroup])
+    itemgroup = fuzzy.FuzzyChoice([c for c in ItemGroup])
     livingaream2 = fuzzy.FuzzyDecimal(0, 99999999999)
     loclvlid = 1
     locsourceid = 4
@@ -91,10 +91,10 @@ class ItemFactory(factory.Factory):
     price = fuzzy.FuzzyDecimal(0, 99999999999)
     price_m2 = fuzzy.FuzzyDecimal(0, 99999999999)
     quarteroftown = fuzzy.FuzzyText(length=60)
-    realtygroup = fuzzy.FuzzyChoice([c.value for c in RealtyGroup])
+    realtygroup = fuzzy.FuzzyChoice([c for c in RealtyGroup])
     realtyidentifier = fuzzy.FuzzyText(length=40)
-    realty_itemgroup = fuzzy.FuzzyChoice([c.value for c in ItemGroup])
-    realtytype = fuzzy.FuzzyChoice([c.value for c in RealtyType])
+    realty_itemgroup = fuzzy.FuzzyChoice([c for c in ItemGroup])
+    realtytype = fuzzy.FuzzyChoice([c for c in RealtyType])
     realtyoption = factory.List([fuzzy.FuzzyText() for _ in range(2)])
     rc_lot_renter = fuzzy.FuzzyText()
     rc_zoninginfo = fuzzy.FuzzyText()
@@ -106,5 +106,5 @@ class ItemFactory(factory.Factory):
     supplier_source_itemcode = fuzzy.FuzzyText()
     text = factory.List([factory.SubFactory(TextFactory) for _ in range(2)])
     town = fuzzy.FuzzyText(length=60)
-    tradetype = fuzzy.FuzzyChoice([c.value for c in TradeType])
+    tradetype = fuzzy.FuzzyChoice([c for c in TradeType])
     zoningname = fuzzy.FuzzyText()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,3 +1,5 @@
+import datetime
+
 import factory
 from factory import fuzzy
 
@@ -60,6 +62,8 @@ class ItemFactory(factory.Factory):
         model = Item
 
     buildyear = fuzzy.FuzzyInteger(0, 9999999999)
+    charges_parkingspace = fuzzy.FuzzyDecimal(0, 99999999999)
+    chargesfinancebasemonth = fuzzy.FuzzyDecimal(0, 99999999999)
     chargesmaintbasemonth = fuzzy.FuzzyDecimal(0, 99999999999)
     chargeswater2 = fuzzy.FuzzyDecimal(0, 99999999999)
     chargeswater2_period = fuzzy.FuzzyText()
@@ -70,25 +74,37 @@ class ItemFactory(factory.Factory):
     cust_itemcode = fuzzy.FuzzyText()
     debtfreeprice = fuzzy.FuzzyDecimal(0, 99999999999)
     dgitemcode = fuzzy.FuzzyText(length=240)
+    extralink = factory.List([factory.SubFactory(ExtraLinkFactory) for _ in range(2)])
+    floors = fuzzy.FuzzyInteger(0, 9999999999)
     energyclass = fuzzy.FuzzyText(length=10)
     holdingtype = fuzzy.FuzzyChoice([c.value for c in HoldingType])
     image = factory.List([factory.SubFactory(ImageFactory) for _ in range(2)])
     itemgroup = fuzzy.FuzzyChoice([c.value for c in ItemGroup])
-    extralink = factory.List([factory.SubFactory(ExtraLinkFactory) for _ in range(2)])
     livingaream2 = fuzzy.FuzzyDecimal(0, 99999999999)
     loclvlid = 1
     locsourceid = 4
+    lotarea = fuzzy.FuzzyDecimal(0, 99999999999)
+    lotareaunitcode = fuzzy.FuzzyText(length=2)
+    lotholding = fuzzy.FuzzyText()
     postcode = fuzzy.FuzzyText(length=5)
+    presentation = fuzzy.FuzzyText()
     price = fuzzy.FuzzyDecimal(0, 99999999999)
+    price_m2 = fuzzy.FuzzyDecimal(0, 99999999999)
     quarteroftown = fuzzy.FuzzyText(length=60)
     realtygroup = fuzzy.FuzzyChoice([c.value for c in RealtyGroup])
     realtyidentifier = fuzzy.FuzzyText(length=40)
     realty_itemgroup = fuzzy.FuzzyChoice([c.value for c in ItemGroup])
     realtytype = fuzzy.FuzzyChoice([c.value for c in RealtyType])
     realtyoption = factory.List([fuzzy.FuzzyText() for _ in range(2)])
+    rc_lot_renter = fuzzy.FuzzyText()
+    rc_zoninginfo = fuzzy.FuzzyText()
+    roof = fuzzy.FuzzyText()
     roomcount = fuzzy.FuzzyInteger(0, 9999999999)
+    showingdate = fuzzy.FuzzyDate(start_date=datetime.date.today())
+    showingdate2 = fuzzy.FuzzyDate(start_date=datetime.date.today())
     street = fuzzy.FuzzyText(length=200)
     supplier_source_itemcode = fuzzy.FuzzyText()
     text = factory.List([factory.SubFactory(TextFactory) for _ in range(2)])
     town = fuzzy.FuzzyText(length=60)
     tradetype = fuzzy.FuzzyChoice([c.value for c in TradeType])
+    zoningname = fuzzy.FuzzyText()

--- a/tests/test_factory_typings.py
+++ b/tests/test_factory_typings.py
@@ -1,0 +1,33 @@
+from tests.factories import (
+    CoordinateFactory,
+    ExtraLinkFactory,
+    ImageFactory,
+    ItemFactory,
+    TextFactory,
+)
+from tests.utils import check_dataclass_typing
+
+
+def test_coordinate_factory_typing():
+    instance = CoordinateFactory()
+    check_dataclass_typing(instance)
+
+
+def test_extra_link_factory_typing():
+    instance = ExtraLinkFactory()
+    check_dataclass_typing(instance)
+
+
+def test_image_factory_typing():
+    instance = ImageFactory()
+    check_dataclass_typing(instance)
+
+
+def test_item_factory_typing():
+    instance = ItemFactory()
+    check_dataclass_typing(instance)
+
+
+def test_text_factory_typing():
+    instance = TextFactory()
+    check_dataclass_typing(instance)

--- a/tests/test_item_to_xml.py
+++ b/tests/test_item_to_xml.py
@@ -10,7 +10,7 @@ from tests.factories import ItemFactory
 
 def test_all_item_attributes_in_xml_string():
     item = ItemFactory()
-    xml_string = object_to_xml_string(item).decode("utf-8")
+    xml_string = object_to_xml_string(item).decode("ISO-8859-1")
 
     for key in item.__dict__.keys():
         assert key in xml_string

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,8 @@
+import typing
+
+
+def check_dataclass_typing(instance):
+    for field_name, field_def in instance.__dataclass_fields__.items():
+        actual_type = typing.get_origin(field_def.type) or field_def.type
+        actual_value = getattr(instance, field_name)
+        assert isinstance(actual_value, actual_type)


### PR DESCRIPTION
- Change the XML encoding to ISO-8859-1 according to the example xml sent by Etuovi.
- Add new fields and update some fields and types according to the latest specs.
- Use enums as item values instead of strings. Use the string values when converting the items to xml.
- Create a (sanitycheck) test that checks that the typing of the factories are correct.

Refs ASU-287