### PR TITLE
Update file creation to return only file

### DIFF
--- a/django_etuovi/etuovi.py
+++ b/django_etuovi/etuovi.py
@@ -40,7 +40,7 @@ def create_xml_file(items: List[BaseClass], file_path: str = ".") -> Tuple[str, 
     filename = get_filename()
     element_tree.write(path.join(file_path, filename),
                        encoding="UTF-8", xml_declaration=True)
-    return file_path, filename
+    return filename
 
 
 def send_items(file_path, filename) -> None:

--- a/tests/test_item_to_xml.py
+++ b/tests/test_item_to_xml.py
@@ -50,7 +50,7 @@ def test_validate_xml_against_dtd():
 @override_settings(ETUOVI_TRANSFER_ID="test", ETUOVI_COMPANY_NAME="ATT")
 def test_xml_created(test_folder):
     items = ItemFactory.create_batch(1)
-    test_folder, test_file = create_xml_file(items, test_folder)
+    test_file = create_xml_file(items, test_folder)
     test_xml = open(path.join(test_folder, test_file), "r")
     test_xml = test_xml.read()
     expected = ["<?xml version='1.0' encoding='UTF-8'?>",


### PR DESCRIPTION
There is no need to return folder path as it is known by file creation requesting service.